### PR TITLE
fix: should not use Node.js v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "helmet": "^3.23.3"
   },
   "engines": {
-    "node": "8.x"
+    "node": "12.x"
   }
 }


### PR DESCRIPTION
Node.js version 8 has been ended in life in December 2019.
https://endoflife.software/programming-languages/server-side-scripting/nodejs

We should use v12 instead of it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
