### PR TITLE
feat: allow to run in localhost

### DIFF
--- a/public/webauthn-client.js
+++ b/public/webauthn-client.js
@@ -45,6 +45,9 @@
           var challenge = credOptions.challenge;
           credOptions.user.id = base64url.decode(credOptions.user.id);
           credOptions.challenge = base64url.decode(credOptions.challenge);
+          if (/localhost/.test(credOptions.rp.id)) {
+            credOptions.rp.id = 'localhost'
+          }
           
           //----------create credentials using available authenticator
           const cred = await navigator.credentials.create({


### PR DESCRIPTION
## Expect behavior

Run the application in local

## Actual Behavior
When running the example application in the localhost, the `navigator.credentials.create` method will throw these errors.

```
The relying party ID is not a registrable domain suffix of, nor equal to the current domain.
```

## Solution
The `credOptions.rp.id` should be `localhost`, but the code will send `localhost:8080`.
So we need to check the id and replace it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
