### PR TITLE
Add region info to AWS CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ $ cd webauthn-with-amazon-cognito
 ```
 ###### Create Cognito resaources and lambda triggers
 ```sh
-$ aws cloudformation create-stack --stack-name webauthn-cognito --template-body file://aws/UserPoolTemplate.yaml --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM CAPABILITY_NAMED_IAM
+$ aws cloudformation create-stack --stack-name webauthn-cognito --template-body file://aws/UserPoolTemplate.yaml --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM CAPABILITY_NAMED_IAM --region us-west-2
 ```
 Wait for the stack to be created successfully and then get the user-pool-id and app-client-id from outputs section. you can do this from CloudFromation console or using describe-stacks command
 ```sh
-$ aws cloudformation describe-stacks --stack-name webauthn-cognito 
+$ aws cloudformation describe-stacks --stack-name webauthn-cognito --region us-west-2
 ```
 Edit the file public/webauthn-client.js to use the new user-pool that you just created.
 ```javascript


### PR DESCRIPTION
The CloudFormation template relies on us-west-2(Oregon) S3 bucket(`webauthn-with-amazon-cognito`).

If you create the stack other than us-west-2, you end up with `CREATE_FAILED`, saying that

> Resource handler returned message: "Error occurred while GetObject. S3 Error Code: PermanentRedirect. S3 Error Message: The bucket is in this region: us-west-2. Please use this region to retry the request

I've updated AWS CLI commands to include region infos.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
