### PR TITLE
Updated app.helmet for CSP

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,7 +7,17 @@ const hbs = require('hbs');
 const authn = require('./libs/authn');
 const helmet = require('helmet');
 const app = express();
-app.use(helmet());
+app.use(helmet({
+    contentSecurityPolicy: {
+        directives: {
+            ...helmet.contentSecurityPolicy.getDefaultDirectives(),
+            'script-src': ["'self'", "'unsafe-inline'", 'https://cdn.jsdelivr.net https://ajax.googleapis.com'],
+            'script-src-attr': ["'self'", "'unsafe-inline'"],
+            'style-src': ["'self'", "'unsafe-inline'", 'https://*.googleapis.com https://www.w3schools.com'],
+            'img-src': ['https:', 'data:'],
+        },
+    },
+}));
 
 
 app.set('view engine', 'html');


### PR DESCRIPTION
Added CSP attributes to allow for localhost to run scripts.

*Issue #, if available:*

*Description of changes:*
When running on LocalHost from Cloud9 - many CSP issues running scripts, stylesheets and in-line functions. CSP attributes added to avoid errors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
